### PR TITLE
Add .gitignore for Next.js project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.next/
+out/
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Summary
- add typical ignores for a Next.js project
- include macOS and Windows ignore patterns

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846665cff20832b9ffb6d86c69228ce