### PR TITLE
Implement game state actions

### DIFF
--- a/pages/game.tsx
+++ b/pages/game.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { useStore } from '../lib/store'
 
 export default function Game() {
-  const { players, bet, timerOn, actions } = useStore()
+  const { players, bet, pot, currentHole, navigationHole, freeLunchOrders, timerOn, actions } = useStore()
 
   useEffect(() => {
     let id: NodeJS.Timeout
@@ -17,6 +17,8 @@ export default function Game() {
       <div id="titleBar" className={`h-10 flex justify-center items-center bg-black font-bold text-lg tracking-wider relative ${timerOn ? 'ring-4 ring-yellow-300' : ''}`}>Avatar G
         {timerOn && <span id="timerHint" className="absolute right-2 top-0.5 text-yellow-300 text-xs animate-pulse">Yellow means Bet timer is on you</span>}
       </div>
+      <div className="text-center py-1 bg-gray-800 text-sm">Hole {currentHole} &bull; Pot ${pot}</div>
+      {navigationHole && <div className="text-center text-xs bg-blue-900 py-1">Navigating to hole {navigationHole}...</div>}
 
       <div className="flex-1 overflow-y-auto p-2 space-y-3">
         {players.map(p => (
@@ -37,12 +39,16 @@ export default function Game() {
         ))}
       </div>
 
-      <div className="sticky bottom-0 bg-gray-900 p-2 flex items-center gap-2">
-        <span id="betAmount" className="w-20 text-center bg-gray-800 text-yellow-300 text-xl">${bet}</span>
-        <button className="arrowBtn w-6 h-6 rounded bg-blue-700 text-white" onClick={() => actions.setBetPerDot(Math.min(200, bet+1))}>▲</button>
-        <button className="arrowBtn w-6 h-6 rounded bg-blue-700 text-white" onClick={() => actions.setBetPerDot(Math.max(1, bet-1))}>▼</button>
-        <button id="yellowPush" className="ml-2 px-6 py-2 bg-yellow-300 text-black font-bold rounded" onClick={() => actions.placeBet()}>Bet</button>
-      </div>
+        {freeLunchOrders.length > 0 && <div className="text-xs text-center bg-green-800 py-1">Lunch ordered for: {freeLunchOrders.join(', ')}</div>}
+        <div className="sticky bottom-0 bg-gray-900 p-2 flex flex-wrap items-center gap-2">
+          <span id="betAmount" className="w-20 text-center bg-gray-800 text-yellow-300 text-xl">${bet}</span>
+          <button className="arrowBtn w-6 h-6 rounded bg-blue-700 text-white" onClick={() => actions.setBetPerDot(Math.min(200, bet+1))}>▲</button>
+          <button className="arrowBtn w-6 h-6 rounded bg-blue-700 text-white" onClick={() => actions.setBetPerDot(Math.max(1, bet-1))}>▼</button>
+          <button id="yellowPush" className="ml-2 px-6 py-2 bg-yellow-300 text-black font-bold rounded" onClick={() => actions.placeBet()}>Bet</button>
+          <button className="px-3 py-2 bg-blue-600 rounded" onClick={() => actions.bankPot()}>Bank</button>
+          <button className="px-3 py-2 bg-purple-600 rounded" onClick={() => actions.openGPS(currentHole)}>GPS</button>
+          <button className="px-3 py-2 bg-green-600 rounded" onClick={() => actions.orderFreeLunch()}>Lunch</button>
+        </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- flesh out actions in `lib/store.ts`
- track hole score, navigation, and free lunch orders in store
- add UI hooks for pot banking, GPS, and lunch order in the game page

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx tsc -p tsconfig.json` *(fails to compile: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6846665bc628832ba645b8d645bcc6ee